### PR TITLE
OPS-227: added docker-compose.yml for calendar

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3'
+
+services:
+  webserver:
+    container_name: calendar
+    image: csunmetalab/api:latest
+    ports:
+      - '8080:80'
+    volumes:
+      - .:/var/www/html
+
+  composer:
+    restart: 'no'
+    container_name: calendar_composer
+    image: composer:latest
+    command: install --ignore-platform-reqs
+    volumes:
+      - .:/app/


### PR DESCRIPTION
# DESCRIPTION
```
docker-compose.yml file for calendar
```
# REQUIREMENTS & DEPENDENCIES
```
Have the docker-compose.yml file in calendar directory
No env available so create base testing .env. Can ask me for it.
If no .env present, a laravel whoops page will occur.
```
# TESTING 

1. Clone calendar repository: `git clone https://github.com/csun-metalab/calendar.git`
2. Input testing .env
3. Import calendar's docker-compose.yml file if it isn't merged yet
4. Run `docker-compose up -d`